### PR TITLE
fix(docs): remove zero-width space breaking Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ stateDiagram-v2
     FinalValidation --> [*]
     DebugSignal --> [*]
 
-    note right of Initialize: Triggered by /sc​:implement --loop
+    note right of Initialize: Triggered by /sc:implement --loop
 ```
 
 **Key Features:**


### PR DESCRIPTION
## Summary
- Fix Mermaid stateDiagram-v2 parse error in LoopOrchestrator section of README.md
- Remove invisible U+200B (zero-width space) character that was breaking GitHub rendering

## Problem
The LoopOrchestrator diagram was showing "Unable to render rich display" error on GitHub due to a hidden zero-width space character between `/sc` and `:implement` on line 251.

## Root Cause
A U+200B (zero-width space) Unicode character was inserted in the `note` annotation:
```
note right of Initialize: Triggered by /sc​:implement --loop
                                          ^^^
                                    (hidden U+200B here)
```

## Test plan
- [ ] Verify Mermaid diagram renders correctly on GitHub after merge
- [ ] Check the LoopOrchestrator section displays the stateDiagram-v2 properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Correct Mermaid stateDiagram-v2 note text in the LoopOrchestrator section of the README so the diagram parses and renders properly on GitHub.