### PR TITLE
fix(docs): escape colon in Mermaid note to fix parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ stateDiagram-v2
     FinalValidation --> [*]
     DebugSignal --> [*]
 
-    note right of Initialize: Triggered by /sc:implement --loop
+    note right of Initialize
+        Triggered by /sc&#58;implement --loop
+    end note
 ```
 
 **Key Features:**


### PR DESCRIPTION
## Summary
- Fix Mermaid stateDiagram-v2 parse error in LoopOrchestrator section
- The previous fix (removing zero-width space) didn't fully resolve the issue

## Root Cause
The **colon in `/sc:implement`** was being interpreted by Mermaid's parser as a state description separator. In stateDiagram-v2, colons have special meaning and need to be escaped in note text.

## Solution
1. Convert from single-line note syntax to multi-line:
   ```mermaid
   note right of Initialize
       Triggered by /sc&#58;implement --loop
   end note
   ```
2. Escape the colon using HTML entity `&#58;`

## References
- [Mermaid State Diagram Docs](https://mermaid.js.org/syntax/stateDiagram.html)
- [GitHub Issue #3289 - Colon operator problems](https://github.com/mermaid-js/mermaid/issues/3289)

## Test plan
- [ ] Verify Mermaid diagram renders correctly on GitHub after merge
- [ ] Check the LoopOrchestrator stateDiagram-v2 displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Adjust LoopOrchestrator Mermaid stateDiagram-v2 note syntax and escape a colon in the command text so the diagram parses correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README diagram formatting to ensure consistent rendering and visual display across documentation viewers and platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->