### PR TITLE
docs: add Claude Code Reference to docs index

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -2,6 +2,7 @@
 
 ## Docs
 
+- [Claude Code Reference](claude-code-reference.md) — Comprehensive CLI, settings, hooks, MCP, skills, subagents, and IDE reference.
 - [Dashboard Guide](dashboard.md) — Using the SuperClaude Tauri dashboard.
 - [Quality Gates](quality-gates.md) — Validator thresholds and scoring rules.
 


### PR DESCRIPTION
## Summary
- Adds a link to the Claude Code Reference document in `Docs/README.md`
- The reference doc provides comprehensive coverage of CLI commands, settings, hooks, MCP configuration, skills, subagents, and IDE integrations

## Test plan
- [x] Link target (`claude-code-reference.md`) exists in `Docs/`
- [x] Markdown formatting matches existing index entries
- [x] Description accurately reflects referenced document content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Link the Claude Code Reference document from the main docs index for easier discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new reference documentation link to the Docs section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->