### PR TITLE
fix: resolve 3 workflow bugs found during integration testing

### DIFF
--- a/.github/workflows/claude-review-phase1.yml
+++ b/.github/workflows/claude-review-phase1.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Check PR size (cost control)
         id: pr_size
         run: |
-          FILES_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | wc -l)
-          LINES_CHANGED=$(git diff --stat origin/${{ github.base_ref }}...HEAD | tail -1 | awk '{print $4+$6}')
+          BASE_REF="${{ github.base_ref }}"
+          BASE_REF="${BASE_REF:-main}"
+          FILES_CHANGED=$(git diff --name-only origin/${BASE_REF}...HEAD | wc -l)
+          LINES_CHANGED=$(git diff --stat origin/${BASE_REF}...HEAD | tail -1 | awk '{print $4+$6}')
 
           echo "files_changed=$FILES_CHANGED" >> $GITHUB_OUTPUT
           echo "lines_changed=$LINES_CHANGED" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude-review-phase2.yml
+++ b/.github/workflows/claude-review-phase2.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check for high-stakes changes
         id: check
         run: |
+          BASE_REF="${{ github.base_ref }}"
+          BASE_REF="${BASE_REF:-main}"
+
           # SuperClaude high-stakes patterns
           HIGH_STAKES_PATTERNS=(
             "agents/core/"
@@ -55,7 +58,7 @@ jobs:
             "secrets/"
           )
 
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only origin/${BASE_REF}...HEAD)
 
           IS_HIGH_STAKES="false"
           SENSITIVE_FILES=""
@@ -206,9 +209,11 @@ jobs:
         if: steps.check-pal.outputs.configured == 'true'
         id: context
         run: |
-          git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr-diff.patch
-          git diff --name-only origin/${{ github.base_ref }}...HEAD | head -10 > /tmp/changed-files.txt
-          LINES_CHANGED=$(git diff --stat origin/${{ github.base_ref }}...HEAD | tail -1 | awk '{print $4+$6}')
+          BASE_REF="${{ github.base_ref }}"
+          BASE_REF="${BASE_REF:-main}"
+          git diff origin/${BASE_REF}...HEAD > /tmp/pr-diff.patch
+          git diff --name-only origin/${BASE_REF}...HEAD | head -10 > /tmp/changed-files.txt
+          LINES_CHANGED=$(git diff --stat origin/${BASE_REF}...HEAD | tail -1 | awk '{print $4+$6}')
           echo "lines_changed=$LINES_CHANGED" >> $GITHUB_OUTPUT
 
       - name: Run PAL MCP Consensus

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -483,6 +483,8 @@ jobs:
       - name: Send Slack notification
         env:
           RUBE_API_TOKEN: ${{ secrets.RUBE_API_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          RUBE_ENTITY_ID: ${{ secrets.RUBE_ENTITY_ID }}
           NOTIFY_KIND: issue-fix
           WORKFLOW_STATUS: ${{ steps.status.outputs.status }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -491,4 +493,9 @@ jobs:
           PR_NUMBER: ${{ needs.create-pr.outputs.pr_number }}
           PR_URL: ${{ needs.create-pr.outputs.pr_url }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: python .github/scripts/notify_slack.py
+        run: |
+          if [ -z "$RUBE_API_TOKEN" ] || [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$RUBE_ENTITY_ID" ]; then
+            echo "::warning::Slack secrets not configured — skipping notifications"
+            exit 0
+          fi
+          python .github/scripts/notify_slack.py

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -368,7 +368,6 @@ jobs:
           fi
 
       - name: Send Slack notification
-        if: env.RUBE_API_TOKEN != ''
         env:
           RUBE_API_TOKEN: ${{ secrets.RUBE_API_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -377,4 +376,9 @@ jobs:
           WORKFLOW_STATUS: ${{ steps.status.outputs.status }}
           AFFECTED_DOCS: ${{ needs.detect-changes.outputs.affected_docs }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: python scripts/notify_slack.py
+        run: |
+          if [ -z "$RUBE_API_TOKEN" ] || [ -z "$SLACK_CHANNEL_ID" ] || [ -z "$RUBE_ENTITY_ID" ]; then
+            echo "::warning::Slack secrets not configured — skipping notifications"
+            exit 0
+          fi
+          python scripts/notify_slack.py

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -57,7 +57,7 @@ jobs:
       run: pip install uv
 
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --extra test
 
     - name: Run tests
       run: uv run pytest -m "not requires_api"


### PR DESCRIPTION
## Summary

Fixes 3 bugs discovered by triggering all 21 GitHub Actions workflows and analyzing their logs:

- **`github.base_ref` empty on `issue_comment`** — Phase 1 and Phase 2 review workflows crash with `fatal: ambiguous argument 'origin/...HEAD'` when triggered by `issue_comment` events. Added `BASE_REF` shell variable with fallback to `main`. (2 files, 6 instances)
- **`package-test.yml` pytest not found** — `uv sync` doesn't install test extras; pytest is in `[project.optional-dependencies] test`. Changed to `uv sync --extra test`. (1 file)
- **Slack notification 400 errors** — `nightly-docs-update.yml` and `issue-to-pr.yml` missing proper secret validation. Added 3-variable shell guard (`RUBE_API_TOKEN`, `SLACK_CHANNEL_ID`, `RUBE_ENTITY_ID`) matching the pattern from `commit-notifications.yml`. (2 files)

### Files Changed
| File | Fix |
|------|-----|
| `claude-review-phase1.yml` | `BASE_REF` fallback (2 instances) |
| `claude-review-phase2.yml` | `BASE_REF` fallback (4 instances across 2 steps) |
| `package-test.yml` | `uv sync` → `uv sync --extra test` |
| `nightly-docs-update.yml` | Remove `if:`, add 3-var Slack guard |
| `issue-to-pr.yml` | Add missing env vars + 3-var Slack guard |

## Test plan
- [x] All edits are in workflow YAML only — no source code changes
- [ ] PR triggers phase1/phase2 on `pull_request` event (tests normal path)
- [ ] Comment `@claude-review` on PR to trigger `issue_comment` event (tests fallback path)
- [ ] Package Tests workflow passes with `--extra test`
- [ ] Slack steps skip gracefully when secrets not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix workflow issues in review, test, and notification GitHub Actions uncovered during integration testing.

Bug Fixes:
- Prevent claude review workflows from failing when github.base_ref is empty by defaulting diffs to main.
- Ensure package test workflow installs test dependencies so pytest is available.
- Avoid Slack notification failures by skipping Slack steps when required secrets are not configured in issue-to-pr and nightly docs workflows.

CI:
- Adjust multiple GitHub Actions workflows to be more robust across different triggering contexts and secret configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request review workflows with improved base branch reference resolution and fallback logic for consistency.
  * Strengthened Slack notification integration by adding required configuration validation.
  * Updated dependency installation to ensure all test-related packages are available in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->