### PR TITLE
fix: use short model alias in issue-to-pr workflow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -131,7 +131,7 @@ jobs:
             echo "${ISSUE_BODY}"
           } | npx -y @anthropic-ai/claude-code \
             --print \
-            --model claude-sonnet-4-6-20250514 \
+            --model claude-sonnet-4-6 \
             --max-turns 30 \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(git diff *),Bash(git log *),Bash(git status),Bash(ruff *),Bash(python -m py_compile *),Bash(pytest *),Bash(ls *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *)"
 
@@ -161,7 +161,7 @@ jobs:
             echo "${ISSUE_BODY}"
           } | npx -y @anthropic-ai/claude-code \
             --print \
-            --model claude-sonnet-4-6-20250514 \
+            --model claude-sonnet-4-6 \
             --max-turns 30 \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(git diff *),Bash(git log *),Bash(git status),Bash(ruff *),Bash(python -m py_compile *),Bash(pytest *),Bash(ls *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *)"
 


### PR DESCRIPTION
## Summary

- Full model ID `claude-sonnet-4-6-20250514` not recognized by Bedrock's model mapping
- Changed to short alias `claude-sonnet-4-6` which Claude Code CLI resolves for both providers

## Test plan
- [ ] Merge and create a test issue to trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Standardize the Claude model identifier in the issue-to-PR workflow to the short claude-sonnet-4-6 alias for broader provider compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model configuration in automated workflow processes for improved consistency and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->