### PR TITLE
fix: use Bedrock-format model ID for issue-to-pr Bedrock step

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -131,7 +131,7 @@ jobs:
             echo "${ISSUE_BODY}"
           } | npx -y @anthropic-ai/claude-code \
             --print \
-            --model claude-sonnet-4-6 \
+            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0 \
             --max-turns 30 \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(git diff *),Bash(git log *),Bash(git status),Bash(ruff *),Bash(python -m py_compile *),Bash(pytest *),Bash(ls *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *)"
 


### PR DESCRIPTION
## Summary

- `CLAUDE_CODE_USE_BEDROCK=1` requires Bedrock-format model IDs (e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`)
- Short aliases like `claude-sonnet-4-6` only work with the Anthropic API
- Bedrock step now uses the exact ID that Bedrock accepts; Anthropic fallback keeps the short alias

## Test plan
- [ ] Merge and create a test issue to verify Bedrock step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Configure the Claude Code invocation in the issue-to-pr workflow to use the full Bedrock model identifier instead of the short alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model used in automated issue processing to a newer version for improved performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->