### PR TITLE
fix: use GITHUB_TOKEN instead of PAT_TOKEN for issue-to-pr

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -39,15 +39,10 @@ jobs:
     env:
       BEDROCK_CONFIGURED: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK != '' }}
       ANTHROPIC_KEY_SET: ${{ secrets.ANTHROPIC_API_KEY != '' }}
-      HAS_PAT: ${{ secrets.PAT_TOKEN != '' }}
 
     steps:
       - name: Validate required secrets
         run: |
-          if [ "$HAS_PAT" != "true" ]; then
-            echo "::error::PAT_TOKEN required for PR creation"
-            exit 1
-          fi
           if [ "$BEDROCK_CONFIGURED" != "true" ] && [ "$ANTHROPIC_KEY_SET" != "true" ]; then
             echo "::error::No API provider configured. Add AWS Bedrock credentials OR ANTHROPIC_API_KEY."
             exit 1
@@ -57,7 +52,7 @@ jobs:
       - name: Check for duplicate PRs
         id: dedup
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           EXISTING_PR=$(gh pr list --repo "${{ github.repository }}" --state open \
             --json number,headRefName \
@@ -90,7 +85,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -355,7 +350,7 @@ jobs:
         if: needs.guardrails.outputs.passed == 'true'
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download clean patch
         if: needs.guardrails.outputs.passed == 'true'
@@ -373,7 +368,7 @@ jobs:
         if: needs.guardrails.outputs.passed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: issue-fix/${{ github.event.issue.number }}-${{ github.run_id }}
           delete-branch: true
           draft: true
@@ -408,7 +403,7 @@ jobs:
       - name: Comment on issue (success)
         if: needs.guardrails.outputs.passed == 'true' && steps.create.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue comment "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" \
@@ -434,7 +429,7 @@ jobs:
       - name: Comment on issue (no PR)
         if: needs.guardrails.outputs.passed != 'true' && needs.validate.outputs.should_proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILURE_REASON: ${{ steps.failure.outputs.reason }}
         run: |
           gh issue comment "${{ github.event.issue.number }}" \


### PR DESCRIPTION
## Summary

- `PAT_TOKEN` lacks push permission → 403 error when `peter-evans/create-pull-request` pushes the branch
- Replaced all `PAT_TOKEN` references with `GITHUB_TOKEN` which already has `contents: write` and `pull-requests: write` from the workflow permissions block
- Removed the `HAS_PAT` validation check (GITHUB_TOKEN is always available)

## Test plan
- [ ] Merge and create a test issue to verify end-to-end: issue → Claude generates code → draft PR created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch the issue-to-pr GitHub Actions workflow from using a personal access token to the built-in GITHUB_TOKEN for PR creation and related operations.

Bug Fixes:
- Resolve 403 errors when the workflow attempts to push branches for pull request creation by using a token with appropriate permissions.

Enhancements:
- Simplify workflow configuration by removing the PAT_TOKEN secret requirement and associated validation check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated the GitHub Actions workflow to use improved authentication methods for automated issue-to-pull-request conversion
- Removed unnecessary validation steps to streamline the process while maintaining all existing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->